### PR TITLE
Removed date from display_version function to support reproducibility

### DIFF
--- a/abcm2ps.c
+++ b/abcm2ps.c
@@ -425,8 +425,7 @@ static void display_version(int full)
 	fputs("abcm2ps-" VERSION " (" VDATE ")\n", log);
 	if (!full)
 		return;
-	fputs("Compiled: " __DATE__ "\n"
-	       "Options:"
+	fputs("Options:"
 #ifdef A4_FORMAT
 		" A4_FORMAT"
 #endif


### PR DESCRIPTION
Hello, I'm submitting this change in order to further the reproducible builds agenda - which aims to ensure all projects built remain bit-by-bit identical uniformly throughout the package.

In this case, the display_version function (abcm2ps.c) was printing a date time stamp, which wasn't allowing this project to build in a reproducible fashion.