### PR TITLE
Add 'cleanconfig' make target to remove all generated objects.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -71,3 +71,6 @@ test:	$(EXAMPLES)
 
 clean:
 	rm -f *.o $(EXAMPLES) # *.obj
+
+cleanconfig: clean
+	rm -f config.h abcm2ps Makefile


### PR DESCRIPTION
The point here is to have an easy make target that nukes the directory down to the ground, allowing for a clean configure and rebuild.