### PR TITLE
documentation updates

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -62,8 +62,8 @@ An alternate option for this creation is to use 'ninja' (ninja-build) or
 'samurai'. These programs use the file 'build.ninja' which may be custumized.
 
 
-Windows or MAC systems
-======================
+Windows or pre-OS X Mac systems
+===============================
 
 You must create the file 'config.h' from the 'config.h.in' skeleton.
 Then, the abcm2ps binary must be created by compiling all the '.c' files
@@ -86,7 +86,8 @@ line argument:
 The resulting file, 'Out.ps', may be displayed using a PostScript
 previewer such as ghostscript or zathura, or it may be sent directly
 to a PostScript printer, or indirectly to a simple printer using
-a postscript filter.
+a postscript filter. OSX/macOS users can view PostScript natively
+with the system default Preview app. Windows users can use GSView.
 
 
 About the 'pango' library

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ but they are closer to the ABC draft 2.2 (February 2013):
 
 ### Installation and usage
 
-The installation procedure is described in the file INSTALL.
+The full installation options are described in the file INSTALL. To build the program with default settings run
+
+```
+./configure
+make
+```
 
 Basically, the program usage is:
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ### Overview
 
-abcm2ps is a program which converts music tunes from the ABC music
-notation to PostScript or SVG.  
+Jean-Francois Moine's abcm2ps is a program which converts music
+tunes from the ABC music notation to PostScript or SVG.
 Based on the abc2ps version 1.2.5 from Michael Methfessel,
 it was first developped to print barock organ scores that have
 independant voices played on one or many keyboards and a pedal-board

--- a/README.md
+++ b/README.md
@@ -4,19 +4,11 @@
 
 ### Overview
 
-Jean-Francois Moine's abcm2ps is a program which converts music
-tunes from the ABC music notation to PostScript or SVG.
-Based on the abc2ps version 1.2.5 from Michael Methfessel,
-it was first developped to print barock organ scores that have
-independant voices played on one or many keyboards and a pedal-board
-(the 'm' of abcm2ps stands for many or multi staves/voices).  
-Since this time, it has evolved so it can render many more music kinds.
+Jean-Francois Moine's abcm2ps is a program which converts music tunes from the ABC music notation to PostScript or SVG. Based on the abc2ps version 1.2.5 from Michael Methfessel, it was first developped to print barock organ scores that have independant voices played on one or many keyboards and a pedal-board (the 'm' of abcm2ps stands for many or multi staves/voices). Since this time, it has evolved so it can render many more music kinds.
 
 ### Features
 
-The main features of abcm2ps are quite the same as the abc2ps ones,
-but they are closer to the ABC draft 2.2 (February 2013):
-
+The main features of abcm2ps are quite the same as the abc2ps ones, but they are closer to the ABC draft 2.2 (February 2013):
     http://abcnotation.com/wiki/abc:standard:v2.2
 
 ### Installation and usage
@@ -32,9 +24,7 @@ Basically, the program usage is:
 
     abcm2ps [options] file1 [file1_options] file2 [file2_options] ...
 
-where file1, file2, .. are the ABC input files. This will generate
-a Postscript file (default name: `Out.ps` - run `abcm2ps -h` to
-know the list of the command line options).
+where file1, file2, .. are the ABC input files. This will generate a Postscript file (default name: `Out.ps`). Run `abcm2ps -h` to know the list of the command line options.
 
 ### Documentation
 


### PR DESCRIPTION
Hi Jef, here are some minor update suggestions for README and INSTALL. Not sure you'll like them all, so I broke them into commits to help you determine what to keep. If you don't like any just ignore this :)

The first is adding build instructions to the readme — new users, especially people used to simply downloading a binary, might look at INSTALL and decide it was too complicated. (When I read it now, it's straight forward. But I remember how confusing it was to me years ago.)

The second adds your name to the readme. It would be easy to not see your name in the Github page description, and anyway that description isn't included in the repo.

The third follows the formatting convention I usually see for Markdown: letting the viewer app handle line breaks. Also puts the ABC Standard link on the same line as the preceding text, matching the formatting of Documentation and Links.

The last clarifies what "MAC" in INSTALL means, and points Mac and Windows users towards PS viewers.