### PR TITLE
Add %%pipeformat to draw as pipeformat in editors like EasyABC

### DIFF
--- a/abcm2ps.h
+++ b/abcm2ps.h
@@ -536,7 +536,7 @@ struct FORMAT { 		/* struct for page layout */
 #ifdef HAVE_PANGO
 	int pango;
 #endif
-	int partsbox, pdfmark;
+	int partsbox, pdfmark, pipeformat;
 	int rbdbstop, rbmax, rbmin;
 	int setdefl, shiftunison, splittune, squarebreve;
 	int staffnonote, straightflags, stretchstaff;

--- a/draw.c
+++ b/draw.c
@@ -1428,6 +1428,7 @@ static void draw_gracenotes(struct SYMBOL *s)
 	/* slur */
 	if (voice_tb[s->voice].key.instr == K_HP	/* no slur when bagpipe */
 	 || voice_tb[s->voice].key.instr == K_Hp
+	 || cfmt.pipeformat
 	 || pipeformat
 	 || !cfmt.graceslurs
 	 || s->u.note.slur_st		/* explicit slur */

--- a/format.c
+++ b/format.c
@@ -110,6 +110,7 @@ static struct format {
 	{"partsfont", &cfmt.font_tb[PARTSFONT], FORMAT_F, 1},
 	{"partsspace", &cfmt.partsspace, FORMAT_U, 0},
 	{"pdfmark", &cfmt.pdfmark, FORMAT_I, 0},
+	{"pipeformat", &cfmt.pipeformat, FORMAT_B, 0},
 	{"rbdbstop", &cfmt.rbdbstop, FORMAT_B, 0},
 	{"rbmax", &cfmt.rbmax, FORMAT_I, 0},
 	{"rbmin", &cfmt.rbmin, FORMAT_I, 0},

--- a/parse.c
+++ b/parse.c
@@ -2760,7 +2760,7 @@ static void set_global_def(void)
 	     p_voice++) {
 		switch (p_voice->key.instr) {
 		case 0:
-			if (!pipeformat) {
+			if (!pipeformat || !cfmt.pipeformat) {
 //				p_voice->transpose = cfmt.transpose;
 				break;
 			}
@@ -2773,6 +2773,10 @@ static void set_global_def(void)
 		}
 //		if (p_voice->key.empty)
 //			p_voice->key.sf = 0;
+		if (cfmt.pipeformat) {
+			if (p_voice->posit.std == 0)
+				p_voice->posit.std = SL_BELOW;
+        }
 		if (!cfmt.autoclef
 		 && p_voice->s_clef
 		 && (p_voice->s_clef->sflags & S_CLEF_AUTO)) {
@@ -4031,7 +4035,7 @@ static void get_key(struct SYMBOL *s)
 					sizeof curvoice->okey);
 		switch (curvoice->key.instr) {
 		case 0:
-			if (!pipeformat) {
+			if (!pipeformat || !cfmt.pipeformat) {
 //				curvoice->transpose = cfmt.transpose;
 				break;
 			}
@@ -4042,6 +4046,10 @@ static void get_key(struct SYMBOL *s)
 				curvoice->posit.std = SL_BELOW;
 			break;
 		}
+		if (cfmt.pipeformat) {
+			if (curvoice->posit.std == 0)
+				curvoice->posit.std = SL_BELOW;
+        }
 		if (curvoice->key.empty)
 			curvoice->key.sf = 0;
 		return;
@@ -4386,7 +4394,7 @@ static void get_note(struct SYMBOL *s)
 
 		if (curvoice->key.instr != K_HP
 		 && curvoice->key.instr != K_Hp
-		 && !pipeformat) {
+		 && !(pipeformat || cfmt.pipeformat)) {
 			div = 2;
 			if (!prev
 			 || !(prev->flags & ABC_F_GRACE)) {

--- a/subs.c
+++ b/subs.c
@@ -1697,6 +1697,7 @@ void write_heading(void)
 	down1 = cfmt.composerspace + cfmt.font_tb[COMPOSERFONT].size;
 	rhythm = ((first_voice->key.instr == K_HP
 		|| first_voice->key.instr == K_Hp
+		|| cfmt.pipeformat
 		|| pipeformat)
 			&& !cfmt.infoline
 			&& (cfmt.fields[0] & (1 << ('R' - 'A'))))


### PR DESCRIPTION
When I'm editing GHB music in EasyABC, I want the Key of D, but without the natural 'G' that Key: Hp provides. This PR creates a "%%pipeformat true" option that allows the editor to draw as though '-p' was set. Default is false, and does not affect the behavior of abcm2ps unless its set.