### PR TITLE
Fix for issue #52, volta bracket length

### DIFF
--- a/abcm2ps.c
+++ b/abcm2ps.c
@@ -479,6 +479,7 @@ static void usage(void)
 		"             0=off 1=left 2=right 3=even left,odd right 4=even right,odd left\n"
 		"     -1      write one tune per page\n"
 		"     -G      no slur in grace notes\n"
+		"     -R      repeat bracket behavior follows the standard\n"
 		"     -j n[b] number the measures every n bars (or on the left if n=0)\n"
 		"             if 'b', display in a box\n"
 		"     -b n    set the first measure number to n\n"
@@ -776,6 +777,10 @@ int main(int argc, char **argv)
 				case 'O':
 					outfn[0] = '\0';
 					break;
+				case 'R':
+					cfmt.repeatstandard = 0;
+					lock_fmt(&cfmt.repeatstandard);
+					break;
 				case 'T': {
 					struct cmdtblt_s *cmdtblt;
 
@@ -874,6 +879,11 @@ int main(int argc, char **argv)
 					break;
 				case 'p':
 				case 'q':
+					break;
+				case 'R':
+					cfmt.repeatstandard = 1;
+					lock_fmt(&cfmt.repeatstandard);
+					break;
 				case 'S':
 					break;
 				case 'v':

--- a/abcm2ps.h
+++ b/abcm2ps.h
@@ -530,7 +530,7 @@ struct FORMAT { 		/* struct for page layout */
 	int barsperstaff, breakoneoln, bstemdown, cancelkey, capo;
 	int combinevoices, contbarnb, continueall, custos;
 	int dblrepbar, decoerr, dynalign, flatbeams, infoline;
-	int gchordbox, graceslurs, graceword,gracespace, hyphencont;
+	int gchordbox, graceslurs, graceword, gracespace, hyphencont;
 	int keywarn, landscape, linewarn;
 	int measurebox, measurefirst, measurenb, micronewps;
 	int oneperpage;
@@ -538,7 +538,7 @@ struct FORMAT { 		/* struct for page layout */
 	int pango;
 #endif
 	int partsbox, pdfmark;
-	int rbdbstop, rbmax, rbmin;
+	int rbdbstop, rbmax, rbmin, repeatstandard;
 	int setdefl, shiftunison, splittune, squarebreve;
 	int staffnonote, straightflags, stretchstaff;
 	int textoption, titlecaps, titleleft, titletrim;

--- a/abcm2ps.rst
+++ b/abcm2ps.rst
@@ -286,6 +286,13 @@ List of the options
 
    When present, only the errors are shown.
 
+-R, +R
+   Repeat brackets follow the abc standard, ending at the next double bar.
+   Default behavior is for the number of measures in the first ending to
+   set the number of measures covered by the brackets in subsequent endings.
+
+   This corresponds to the ``%%repeatstandard`` formatting parameter.
+
 -s <float>
    Set the page scale factor to <float>. Note that the header
    and footer are not scaled (default: 0.75).

--- a/format.c
+++ b/format.c
@@ -114,6 +114,7 @@ static struct format {
 	{"rbmax", &cfmt.rbmax, FORMAT_I, 0},
 	{"rbmin", &cfmt.rbmin, FORMAT_I, 0},
 	{"repeatfont", &cfmt.font_tb[REPEATFONT], FORMAT_F, 0},
+	{"repeatstandard", &cfmt.repeatstandard, FORMAT_B, 0},
 	{"rightmargin", &cfmt.rightmargin, FORMAT_U, 1},
 //	{"scale", &cfmt.scale, FORMAT_R, 0},
 	{"setdefl", &cfmt.setdefl, FORMAT_B, 0},
@@ -405,6 +406,7 @@ void set_format(void)
 	f->rbdbstop = 1;
 	f->rbmax = 4;
 	f->rbmin = 2;
+	f->repeatstandard = 0;
 	f->staffnonote = 1;
 	f->titletrim = 1;
 	f->aligncomposer = A_RIGHT;

--- a/music.c
+++ b/music.c
@@ -3521,7 +3521,7 @@ static void set_rb(struct VOICE_S *p_voice)
 				if (!s->next) {
 					s->flags |= ABC_F_RBSTOP;
 					s->sflags |= S_RBSTOP;
-				} else if (n == mx) {
+				} else if (n == mx && !cfmt.repeatstandard) {
 					s->sflags |= S_RBSTOP;
 				}
 			}


### PR DESCRIPTION
Added a flag and format parameter to make volta brackets follow the ABC standard, rather than calculating their length from the first ending and applying that to subsequent endings. The default behavior is no change, but "-R" or "the %%repeatstandard" parameter triggers the standard-compliant behavior (which is to ignore the length calculated in the first ending and just stop the bracket at the next double bar, or when explicitly stopped with a decoration).