### PR TITLE
Add boolean option nowrap

### DIFF
--- a/abcm2ps.h
+++ b/abcm2ps.h
@@ -534,6 +534,7 @@ struct FORMAT { 		/* struct for page layout */
 	int keywarn, landscape, linewarn;
 	int measurebox, measurefirst, measurenb, micronewps;
 	int oneperpage;
+	int nowrap;
 #ifdef HAVE_PANGO
 	int pango;
 #endif

--- a/format.c
+++ b/format.c
@@ -98,6 +98,7 @@ static struct format {
 	{"musicfont", &cfmt.musicfont, FORMAT_S, 1},
 	{"musicspace", &cfmt.musicspace, FORMAT_U, 0},
 	{"notespacingfactor", &cfmt.notespacingfactor, FORMAT_R, 1},
+	{"nowrap", &cfmt.nowrap, FORMAT_B, 0},
 	{"oneperpage", &cfmt.oneperpage, FORMAT_B, 0},
 	{"pageheight", &cfmt.pageheight, FORMAT_U, 1},
 	{"pagewidth", &cfmt.pagewidth, FORMAT_U, 1},

--- a/music.c
+++ b/music.c
@@ -4782,7 +4782,8 @@ static void set_sym_glue(float width)
 			float space;
 
 			xmin += s->shrink;
-			if ((space = s->space) < s->shrink)
+			space = s->space;
+			if (!cfmt.nowrap && space < s->shrink)
 				space = s->shrink;
 			x += space;
 			if (cfmt.stretchstaff)

--- a/music.c
+++ b/music.c
@@ -2219,7 +2219,7 @@ static void cut_tune(float lwidth, float indent)
 		if (!(s->sflags & (S_SEQST | S_EOLN)))
 			continue;
 		xmin += s->shrink;
-		if (xmin > lwidth) {
+		if (!cfmt.nowrap && xmin > lwidth) {
 			if (cfmt.linewarn)
 				error(0, s, "Line overfull (%.0fpt of %.0fpt)",
 					xmin, lwidth);
@@ -4903,7 +4903,7 @@ static void set_sym_glue(float width)
 			alfa = 1;			// no extra space
 		} else {
 			alfa = (x - width) / (x - xmin);	/* shrink */
-			if (alfa > 1) {
+			if (!cfmt.nowrap && alfa > 1) {
 				error(1, s,
 				      "Line too much shrunk (%.0f/%0.fpt of %.0fpt)",
 					xmin, x, width);


### PR DESCRIPTION
This option disables line wrapping, instead allowing unlimited shrink.
Useful either with barsperstaff or manual linebreaks.

There may be another way to achieve this, but I was having trouble formatting the bars that I wanted per line without going to landscape mode. 