### PR TITLE
Add option flatbeamgracing that applies flat beams to grace notes

### DIFF
--- a/abcm2ps.h
+++ b/abcm2ps.h
@@ -529,7 +529,7 @@ struct FORMAT { 		/* struct for page layout */
 	int abc2pscompat, alignbars, aligncomposer, autoclef;
 	int barsperstaff, breakoneoln, bstemdown, cancelkey, capo;
 	int combinevoices, contbarnb, continueall, custos;
-	int dblrepbar, decoerr, dynalign, flatbeams, infoline;
+	int dblrepbar, decoerr, dynalign, flatbeams, flatbeamgracing, infoline;
 	int gchordbox, graceslurs, graceword,gracespace, hyphencont;
 	int keywarn, landscape, linewarn;
 	int measurebox, measurefirst, measurenb, micronewps;

--- a/draw.c
+++ b/draw.c
@@ -304,6 +304,9 @@ if (s1->xs == s2->xs)
 /*  if (nflags>1) b=b+2*stem;*/	/* leave a bit more room if several beams */
 
 	/* have flat beams when asked */
+	if ( cfmt.flatbeamgracing && s1->flags & ABC_F_GRACE)
+		a = 0;
+
 	if (cfmt.flatbeams) {
 //		if (!(s1->flags & ABC_F_GRACE))
 //			b = -11 + staff_tb[staff].y;

--- a/format.c
+++ b/format.c
@@ -68,6 +68,7 @@ static struct format {
 	{"footer", &cfmt.footer, FORMAT_S, 0},
 	{"footerfont", &cfmt.font_tb[FOOTERFONT], FORMAT_F, 0},
 	{"flatbeams", &cfmt.flatbeams, FORMAT_B, 0},
+	{"flatbeamgracing", &cfmt.flatbeamgracing, FORMAT_B, 0},
 	{"gchordbox", &cfmt.gchordbox, FORMAT_B, 0},
 	{"gchordfont", &cfmt.font_tb[GCHORDFONT], FORMAT_F, 3},
 	{"graceslurs", &cfmt.graceslurs, FORMAT_B, 0},


### PR DESCRIPTION
This simple change is a subset of the `flatbeams` parameter. This version only flattens the grace notes, while leaving the normal notes sloped. 

I think this is useful to bagpipers, it is how I personally expect bagpipe music to look.